### PR TITLE
Update Docker image to Plone 6.1.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 IMAGE_NAME="docker-staging.imio.be/iadelib/citizenportal:latest"
+BUILD_NUMBER ?= local
 
 all: dev
 
@@ -29,4 +30,4 @@ bootstrap:
 
 .PHONY: docker-image
 docker-image:
-	docker build --no-cache --pull -t iadelib/citizenportal:latest .
+	docker build --no-cache --pull -f docker/Dockerfile --build-arg build_number=$(BUILD_NUMBER) -t iadelib/citizenportal:latest .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM harbor.imio.be/common/plone-base:6.1.2 AS builder
+FROM harbor.imio.be/common/plone-base:6.1.4 AS builder
 
-ENV ZC_BUILDOUT=4.1.4 \
+ENV ZC_BUILDOUT=4.1.12 \
     PLONE_MAJOR=6.1 \
-    PLONE_VERSION=6.1.2
+    PLONE_VERSION=6.1.4
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential \
@@ -47,10 +47,10 @@ RUN /plone/bin/buildout -c docker.cfg -t 30 -N
 #  && rm -rf /var/lib/apt/lists/*
 
 
-FROM harbor.imio.be/common/plone-base:6.1.2
+FROM harbor.imio.be/common/plone-base:6.1.4
 ARG build_number
-ENV ZC_BUILDOUT=4.1.4 \
-  PLONE_VERSION=6.1.0 \
+ENV ZC_BUILDOUT=4.1.12 \
+  PLONE_VERSION=6.1.4 \
   HOSTNAME_HOST=local \
   PROJECT_ID=delib \
   PLONE_EXTENSION_IDS=plone.app.caching:default,plonetheme.barceloneta:default,plonemeeting.portal.core:default \

--- a/prod.cfg
+++ b/prod.cfg
@@ -1,7 +1,7 @@
 [buildout]
 extends =
-    https://dist.plone.org/release/6.1.2/versions.cfg
-    https://dist.plone.org/release/6.1.2/versions-extra.cfg
+    https://dist.plone.org/release/6.1.4/versions.cfg
+    https://dist.plone.org/release/6.1.4/versions-extra.cfg
     base.cfg
 
 extensions =

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 packaging==25.0
 pip==25.3
 setuptools==80.9.0
-wheel==0.45.1
+wheel>=0.46.2
 zc.buildout==4.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 packaging==25.0
-pip==25.1.1
+pip==25.3
 setuptools==80.9.0
-wheel==0.46.2
+wheel==0.45.1
 zc.buildout==4.1.12

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,8 +1,8 @@
 [versions]
 packaging = 25.0
-pip = 25.1.1
+pip = 25.3
 setuptools = 80.9.0
-wheel = 0.46.1
+wheel = 0.45.1
 zc.buildout = 4.1.12
 
 plonemeeting.portal.core = 2.4.1

--- a/versions.cfg
+++ b/versions.cfg
@@ -2,7 +2,7 @@
 packaging = 25.0
 pip = 25.3
 setuptools = 80.9.0
-wheel = 0.45.1
+wheel = 0.46.2
 zc.buildout = 4.1.12
 
 plonemeeting.portal.core = 2.4.1


### PR DESCRIPTION
## Summary

Bump the Docker image and buildout to **Plone 6.1.4** (base image `harbor.imio.be/common/plone-base:6.1.4`), keeping installed packages and build tooling consistent with that release.

## Changes

- **`docker/Dockerfile`** — base image `6.1.2 → 6.1.4` in both stages; `ZC_BUILDOUT 4.1.4 → 4.1.12`; `PLONE_VERSION → 6.1.4` (was `6.1.2` in builder, stale `6.1.0` in final).
- **`prod.cfg`** — Plone release pins (`versions.cfg` / `versions-extra.cfg`) `6.1.2 → 6.1.4`. These drive the package versions buildout installs in the image (`docker.cfg` extends `prod.cfg`).
- **`requirements.txt` / `versions.cfg`** — align build tooling with Plone 6.1.4 pins: `pip 25.1.1 → 25.3`, `wheel → 0.45.1` (a downgrade; `packaging`, `setuptools`, `zc.buildout` already matched).
- **`Makefile`** — fix the `docker-image` target: add `-f docker/Dockerfile` (no Dockerfile in repo root) and pass `--build-arg build_number=$(BUILD_NUMBER)`, matching the CI invocation.

> `dev.cfg` extends `plone-6.1.x.cfg` (latest 6.1.x line), so it needs no change.

## Verification

- `harbor.imio.be/common/plone-base:6.1.4` pulls successfully — the new tag exists and is reachable.
- Full image build (`docker build -f docker/Dockerfile ... .`) completes with exit 0; `bin/buildout -c docker.cfg` resolves cleanly against the 6.1.4 pins and generates all instance scripts — no version conflicts.
- Resulting image: `iadelib/citizenportal` (1.23 GB).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Plone to 6.1.4 for improved stability and compatibility.
  * Made build artifacts include a configurable build number for deployment tracking.
  * Updated build/runtime base images to align with the Plone upgrade.
  * Updated Python tooling: pip -> 25.3, packaging -> 25.0, setuptools -> 80.9.0, wheel -> >=0.46.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->