### PR TITLE
Register Docker cron tick idempotently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Release 2.4.9
+
+**Date:** 2026-06-15
+
+
+- Docker: register the cron tick idempotently. The entrypoint now overwrites
+  the ``imio`` crontab instead of appending to it, so restarting an instance
+  (``docker start`` / ``restart: always``) no longer accumulates duplicate
+  ``*/15 * * * * /tick.sh`` entries that fire the tick multiple times.
+  [aduchene]
+
 ## Release 2.4.8
 
 **Date:** 2026-06-15

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -12,7 +12,7 @@ if [ "$CRON" = "True" ]; then
   echo -e "machine localhost\nlogin admin\npassword $ADMIN_PASSWORD" > ./.netrc
   chmod 600 ./.netrc
   touch /data/log/cron.log
-  (crontab -u imio -l 2>/dev/null ; echo "*/15 * * * * /tick.sh $SITE_ID") | crontab -
+  echo "*/15 * * * * /tick.sh $SITE_ID" | crontab -
   /cron.sh &
 fi
 


### PR DESCRIPTION
## Problem

The cron tick was firing multiple times within a single instance after restarts.

`docker/docker-entrypoint.sh` registered the tick by **appending** to the existing crontab:

```bash
(crontab -u imio -l 2>/dev/null ; echo "*/15 * * * * /tick.sh $SITE_ID") | crontab -
```

A container's filesystem (and the crontab spool) survives `docker start` and `restart: always` — only a recreate resets them — and `docker start` re-runs the entrypoint. So every restart appended **another** `*/15 * * * * /tick.sh` line, and the tick fired once per accumulated entry.

## Fix

Overwrite the crontab with a single line instead of appending, making registration idempotent across any number of restarts:

```bash
echo "*/15 * * * * /tick.sh $SITE_ID" | crontab -
```

The `imio` crontab is only ever used for this tick (the Dockerfile seeds it empty, the entrypoint is the sole writer), so replacing it wholesale is safe.

## Notes

- The per-instance `CRON=True` gate is unaffected and verified working — cron runs only on `instance1`.
- Takes effect once the image is rebuilt and pushed.
- Changelog entry added under Release 2.4.9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate scheduled task entries that could accumulate during container restarts by modifying how cron jobs are configured in Docker environments.

* **Documentation**
  * Added Release 2.4.9 changelog entry detailing updates to Docker cron scheduling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->