### PR TITLE
DELIBE-311: GenericSetup upgrade helpers in the delib image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Release 2.4.13
+
+**Date:** 2026-06-17
+
+
+### buildout.pm.portal
+
+- Bake the deliberations.be deploy-automation upgrade helpers into the image
+  (`scripts/check-pending-upgrades.py`, `scripts/run-upgrades.py`) and remove the
+  dead `scripts/run_portal_upgrades.py` (it imported `collective.upgrade`, which
+  is not installed in the image). (DELIBE-311)
+  [aduchene]
+
 ## Release 2.4.12
 
 **Date:** 2026-06-16

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -4,8 +4,8 @@ name: "délibérations.be"
 applicationSuite: "iA.Délib"
 url: "https://github.com/IMIO/buildout.pm.portal"
 landingURL: "https://github.com/IMIO/buildout.pm.portal"
-softwareVersion: "2.4.12"
-releaseDate: "2026-06-16"
+softwareVersion: "2.4.13"
+releaseDate: "2026-06-17"
 logo: ".github/img/logo.svg"
 
 platforms:

--- a/scripts/check-pending-upgrades.py
+++ b/scripts/check-pending-upgrades.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Prints "PENDING=<n>" — the number of proposed GenericSetup upgrade steps for
+# the Plone site(s) in this instance. Run inside an instance container:
+#   ./bin/instance run check-pending-upgrades.py
+#
+# The target site is taken from the SITE_ID env var (set in the compose for the
+# instance); if absent or not found, every Plone site under the Zope root is
+# summed. We deliberately do NOT read sys.argv: `bin/instance run` does not pass
+# script arguments through cleanly (the interpreter's own -c leaks in).
+import os
+from Acquisition import aq_base
+
+
+def iter_plone_sites(app):
+    site_id = os.environ.get('SITE_ID')
+    if site_id and site_id in app.objectIds():
+        yield app[site_id]
+        return
+    for obj in app.objectValues():
+        if hasattr(aq_base(obj), 'portal_setup'):
+            yield obj
+
+
+def count_pending(setup):
+    pending = 0
+    try:
+        profiles = setup.listProfilesWithPendingUpgrades()
+    except AttributeError:
+        profiles = [p['id'] for p in setup.listProfileInfo()]
+    for profile_id in profiles:
+        try:
+            steps = setup.listUpgrades(profile_id)
+        except (KeyError, AttributeError):
+            continue
+        for entry in steps:
+            group = entry if isinstance(entry, list) else [entry]
+            pending += sum(1 for s in group if s.get('proposed', True))
+    return pending
+
+
+def main(app):
+    total = 0
+    for portal in iter_plone_sites(app):
+        total += count_pending(portal.portal_setup)
+    print('PENDING=%d' % total)
+
+
+if __name__ == '__main__':
+    main(app)  # noqa: F821 - `app` is injected by `bin/instance run`

--- a/scripts/run-upgrades.py
+++ b/scripts/run-upgrades.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Run every pending GenericSetup upgrade step for the Plone site(s), then commit.
+#   ./bin/instance run scripts/run-upgrades.py
+import os
+import transaction
+from AccessControl.SecurityManagement import newSecurityManager
+from Acquisition import aq_base
+from Testing.makerequest import makerequest
+from zope.component.hooks import setSite
+
+
+def iter_plone_sites(app):
+    site_id = os.environ.get('SITE_ID')
+    if site_id and site_id in app.objectIds():
+        yield app[site_id]
+        return
+    for obj in app.objectValues():
+        if hasattr(aq_base(obj), 'portal_setup'):
+            yield obj
+
+
+def become_admin(app):
+    # Mirror collective.big.bang: run as the Zope root 'admin' (Manager
+    # everywhere) so upgrade steps that check permissions succeed.
+    user = app.acl_users.getUser('admin')
+    if user is not None:
+        newSecurityManager(None, user.__of__(app.acl_users))
+
+
+def upgrade_site(portal):
+    setSite(portal)
+    setup = portal.portal_setup
+    profiles = list(setup.listProfilesWithPendingUpgrades())
+    for profile_id in profiles:
+        setup.upgradeProfile(profile_id)
+        print('UPGRADED=%s' % profile_id)
+    return len(profiles)
+
+
+def main(app):
+    app = makerequest(app)
+    become_admin(app)
+    total = 0
+    for portal in iter_plone_sites(app):
+        total += upgrade_site(portal)
+    transaction.commit()
+    print('UPGRADED_PROFILES=%d' % total)
+
+
+if __name__ == '__main__':
+    main(app)  # noqa: F821 - `app` is injected by `bin/instance run`

--- a/scripts/run_portal_upgrades.py
+++ b/scripts/run_portal_upgrades.py
@@ -1,4 +1,0 @@
-#!/usr/bin/env python
-from collective.upgrade import run
-
-run.run(app)  # noqa


### PR DESCRIPTION
Adds two small Python helpers, baked into the image via the existing Dockerfile `COPY scripts /plone/scripts`, used by the deliberations.be deploy automation (DELIBE-311):

- `scripts/check-pending-upgrades.py` — prints `PENDING=<n>`, the number of pending GenericSetup upgrade steps for the site (`SITE_ID`, or scans the Zope root). Lets the deployer decide whether a release needs to run upgrades.
- `scripts/run-upgrades.py` — applies every pending upgrade via `portal_setup.upgradeProfile()` (as admin) then commits.

Both are invoked from inside the container with `bin/instance run scripts/<name>.py`, so the right upgrade logic ships with each image.

Also removes the dead `scripts/run_portal_upgrades.py` — it did `from collective.upgrade import run`, and `collective.upgrade` is not installed in the delib image.

The deployer itself (`deploy.sh`) and the Rundeck job live in their own repos; only the in-image helpers belong here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a utility script that inspects Plone sites and prints the total number of pending GenericSetup upgrade profiles (`PENDING=<n>`), preferring `SITE_ID` when available.
  * Added a utility script that upgrades all pending GenericSetup profiles for the selected sites, printing each upgraded profile (`UPGRADED=<profile_id>`) and a final total (`UPGRADED_PROFILES=<total>`).
* **Chores**
  * Removed the automatic execution behavior from the previous portal-upgrades runner so it no longer triggers upgrades when launched.
* **Documentation**
  * Updated release metadata to version **2.4.13**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->