### PR TITLE
OIA-241: pin httpx2 + authlib for imio.omnia.core OAuth2 support

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -152,4 +152,15 @@ anyio = 4.13.0
 
 # Required by:
 # imio.omnia.assistant==1.0a1
+# TODO: drop this pin once imio.omnia.assistant releases without its unused httpx dependency
 httpx = 0.28.1
+
+# Required by:
+# imio.omnia.core OAuth 2.0 support
+httpx2 = 2.7.0
+authlib = 1.7.2
+httpcore2 = 2.7.0
+
+# Required by:
+# httpx2==2.7.0 (idna>=3.18, above the Plone 6.1 KGS pin of 3.11)
+idna = 3.18


### PR DESCRIPTION
Companion to IMIO/imio.omnia.core#2 ([OIA-241](https://support-imio.atlassian.net/browse/OIA-241)).

versions.cfg only:
- Add `httpx2 = 2.7.0`, `authlib = 1.7.2`, `httpcore2 = 2.7.0`.
- Override `idna = 3.18` (httpx2 needs >=3.18, above the Plone 6.1 KGS pin of 3.11).
- Keep `httpx = 0.28.1` for now with a TODO — droppable once the imio.omnia.assistant release without its unused httpx dependency is pinned here (DELIBE-322 tracks the wider sweep).

[OIA-241]: https://support-imio.atlassian.net/browse/OIA-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency documentation with clearer “required by” relationships for HTTP/authentication components.
  * Pinned the `idna` version more explicitly to match the related HTTP constraint.
  * Added a TODO note indicating the `httpx` pin can be removed in a future release when it’s no longer needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->